### PR TITLE
Save in db analysis and spell check of resume

### DIFF
--- a/src/pages/ResumePage.tsx
+++ b/src/pages/ResumePage.tsx
@@ -71,14 +71,13 @@ export const ResumePage: React.FC = () => {
                     if (responseResume.status !== HttpStatusCode.Ok) {
                         throw new Error('Failed to analyze file');
                     }
-                    const parsedData = JSON.parse(responseResume.data);
 
-                    setResumeAnalysisResult(parsedData);
+                    setResumeAnalysisResult(responseResume.data);
                 }
                 setShowAnalyzeResult(true);
                 setShowGrammarCheckResult(false);
             } else {
-                toast.error('No user conected');
+                toast.error('No user connected');
             }
         } catch (error) {
             console.error('Error analyzing file:', error);
@@ -106,7 +105,7 @@ export const ResumePage: React.FC = () => {
                 setShowAnalyzeResult(false);
                 setShowGrammarCheckResult(true);
             } else {
-                toast.error('No user conected');
+                toast.error('No user connected');
             }
         } catch (error) {
             console.error('Error checking grammar:', error);

--- a/src/pages/ResumePage.tsx
+++ b/src/pages/ResumePage.tsx
@@ -39,23 +39,24 @@ export const ResumePage: React.FC = () => {
         }
     };
 
+    const resetResults = () => {
+        setGrammarCheckResult(null);
+        setResumeAnalysisResult(null);
+        setShowAnalyzeResult(false);
+        setShowGrammarCheckResult(false);
+    };
+
     useEffect(() => {
         checkAndLoadResume();
 
         return () => {
             setResumeText(null);
-            setResumeAnalysisResult(null);
-            setGrammarCheckResult(null);
-            setShowAnalyzeResult(false);
-            setShowGrammarCheckResult(false);
+            resetResults();
         };
     }, [userContext?.id]);
 
     useEffect(() => {
-        setGrammarCheckResult(null);
-        setResumeAnalysisResult(null);
-        setShowAnalyzeResult(false);
-        setShowGrammarCheckResult(false);
+        resetResults();
     }, [resumeText]);
 
     const onAnalyzeClick = async () => {
@@ -120,6 +121,7 @@ export const ResumePage: React.FC = () => {
             <Box display="flex" justifyContent="flex-start" mb={2}>
                 <ResumeUploadButton
                     onUploadSuccess={async () => {
+                        resetResults();
                         await checkAndLoadResume();
                     }}
                 />


### PR DESCRIPTION
Changed how the client gets the resume analyze because of change in the llm and db.
Added reset states when a new resume is uploaded that was missing

connected to:
https://github.com/work-wise-project/server/pull/29
https://github.com/work-wise-project/data-manager-service/pull/24
https://github.com/work-wise-project/LLM-service/pull/15